### PR TITLE
Independent cache storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ composer.json
 Usage
 -----
 
-Create a new Hi instance and specify a directory where a downloaded content will be cached - you don't want to call the API for the same name again and again.
+Create a new Hi instance and specify a caching storage where the downloaded content will be cached - you don't want to call the API for the same name again and again.
 Additionally, you can set if you are looking for a name or a surname.
 
-    $hi = new Hi('path/to/cache/dir');
-    $hi->setType(\ondrs\Hi\Hi::TYPE_SURNAME)
+    $hi = new ondrs\Hi\Hi(new Nette\Caching\FileStorage('path/to/cache/dir'));
+    $hi->setType(ondrs\Hi\Hi::TYPE_SURNAME)
 
 Call appropriate method (mr() or ms()) according to assumed gender.
 If you are not sure about the gender, call the method to().

--- a/src/ondrs/Hi/Hi.php
+++ b/src/ondrs/Hi/Hi.php
@@ -3,6 +3,7 @@
 namespace ondrs\Hi;
 
 use Nette\Caching\Cache;
+use Nette\Caching\IStorage;
 use Nette\Caching\Storages\FileStorage;
 use Nette\Utils\FileSystem;
 use Nette\Utils\Json;
@@ -32,14 +33,12 @@ class Hi
 
 
     /**
-     * @param string $cacheDir
+     * @param IStorage $storage
      * @param SimpleCurl|NULL $simpleCurl
      */
-    public function __construct($cacheDir, SimpleCurl $simpleCurl = NULL)
+    public function __construct(IStorage $storage, SimpleCurl $simpleCurl = NULL)
     {
-        FileSystem::createDir($cacheDir);
-        
-        $this->cache = new Cache(new FileStorage($cacheDir));
+        $this->cache = new Cache($storage);
         
         $this->simpleCurl = $simpleCurl === NULL
             ? new SimpleCurl

--- a/tests/ondrs/Hi/HiTest.phpt
+++ b/tests/ondrs/Hi/HiTest.phpt
@@ -21,11 +21,18 @@ class HiTest extends TestCase
     {
         $simpleCurl = \Mockery::mock('ondrs\Hi\SimpleCurl')
             ->shouldReceive('get')
-            ->once()
             ->andReturn(file_get_contents(__DIR__ . '/data.json'))
             ->getMock();
 
-        $hi = new Hi(TEMP_DIR, $simpleCurl);
+        $iStorage = \Mockery::mock('Nette\Caching\IStorage')
+            ->shouldReceive('read')
+            ->shouldReceive('lock')
+            ->shouldReceive('remove')
+            ->shouldReceive('write')
+            ->shouldReceive('read')
+            ->getMock();
+
+        $hi = new Hi($iStorage, $simpleCurl);
 
 
         $result1 = $hi->to('plšek');


### PR DESCRIPTION
The client now uses independent cache storage represented by interface `Nette\Caching\IStorage` rather than forcing `Nette\Caching\FileStorage`. This way, Redis and other storages can be used.

However, this is a BC Break.
